### PR TITLE
Update from deprecated channels.list api to conversations.list

### DIFF
--- a/machine/clients/singletons/slack.py
+++ b/machine/clients/singletons/slack.py
@@ -68,7 +68,7 @@ class LowLevelSlackClient(metaclass=Singleton):
         logger.debug("Users: %s" % ", ".join([f"{u.profile.display_name}|{u.profile.real_name}"
                                               for u in self._users.values()]))
         # Build channel cache
-        all_channels = call_paginated_endpoint(self.web_client.channels_list, 'channels')
+        all_channels = call_paginated_endpoint(self.web_client.conversations_list, 'channels', types='public_channel,private_channel')
         for c in all_channels:
             self._register_channel(c)
         logger.debug("Number of channels found: %s" % len(self._channels))

--- a/machine/models/channel.py
+++ b/machine/models/channel.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from dacite import from_dict
 
@@ -29,10 +29,10 @@ class Channel:
     is_member: bool
     is_private: bool
     is_mpim: bool
-    members: List[str]
+    members: Optional[List[str]]
     topic: PurposeTopic
     purpose: PurposeTopic
-    previous_names: List[str]
+    previous_names: Optional[List[str]]
 
     @staticmethod
     def from_api_response(user_reponse: Dict[str, Any]) -> 'Channel':


### PR DESCRIPTION
This switches the channel cache to being built via the conversations.list api instead of the deprecated channels.list api and also includes private channels the bot may be a part of in the channel cache.

It also makes parts of the channels datastructure optional to accomodate private channels